### PR TITLE
Meter needs current time to calculate tick age

### DIFF
--- a/metriki-core/src/global.rs
+++ b/metriki-core/src/global.rs
@@ -13,12 +13,13 @@ pub fn global_registry() -> Arc<MetricsRegistry> {
 
 #[cfg(test)]
 mod test {
+    use std::time::Instant;
     use super::global_registry;
 
     #[test]
     fn test_global_registry() {
         let registry = global_registry();
-        registry.meter("hello").mark();
+        registry.meter("hello").mark(Instant::now());
 
         assert!(registry.snapshots().len() > 0);
     }

--- a/metriki-core/src/metrics/meter.rs
+++ b/metriki-core/src/metrics/meter.rs
@@ -27,28 +27,28 @@ impl Meter {
         }
     }
 
-    pub fn mark(&self) {
-        self.mark_n(1)
+    pub fn mark(&self, current_tick: Instant) {
+        self.mark_n(1, current_tick)
     }
 
-    pub fn mark_n(&self, n: u64) {
+    pub fn mark_n(&self, n: u64, current_tick: Instant) {
         self.count.fetch_add(n, Ordering::Relaxed);
-        self.moving_avarages.tick_if_needed();
+        self.moving_avarages.tick_if_needed(current_tick);
         self.moving_avarages.update(n);
     }
 
-    pub fn m1_rate(&self) -> f64 {
-        self.moving_avarages.tick_if_needed();
+    pub fn m1_rate(&self, current_tick: Instant) -> f64 {
+        self.moving_avarages.tick_if_needed(current_tick);
         self.moving_avarages.m1_rate()
     }
 
-    pub fn m5_rate(&self) -> f64 {
-        self.moving_avarages.tick_if_needed();
+    pub fn m5_rate(&self, current_tick: Instant) -> f64 {
+        self.moving_avarages.tick_if_needed(current_tick);
         self.moving_avarages.m5_rate()
     }
 
-    pub fn m15_rate(&self) -> f64 {
-        self.moving_avarages.tick_if_needed();
+    pub fn m15_rate(&self, current_tick: Instant) -> f64 {
+        self.moving_avarages.tick_if_needed(current_tick);
         self.moving_avarages.m15_rate()
     }
 
@@ -163,9 +163,8 @@ impl ExponentiallyWeightedMovingAverages {
         self.m15.update(n);
     }
 
-    fn tick_if_needed(&self) {
+    fn tick_if_needed(&self, current_tick: Instant) {
         let previous_tick = self.last_tick.load();
-        let current_tick = Instant::now();
 
         let tick_age = (current_tick - previous_tick).as_millis() as u64;
 

--- a/metriki-core/src/metrics/timer.rs
+++ b/metriki-core/src/metrics/timer.rs
@@ -44,7 +44,7 @@ impl TimerContextArc {
     /// Start a timer context for recording that started at given time.
     /// The returned `TimerContext` can be stopped or dropped to record its timing.
     pub fn start_at(timer: Arc<Timer>, start_at: Instant) -> TimerContextArc {
-        timer.rate.mark();
+        timer.rate.mark(Instant::now());
         TimerContextArc { start_at, timer }
     }
 
@@ -74,7 +74,7 @@ impl Timer {
     /// Start a timer context for recording that started at given time.
     /// The returned `TimerContext` can be stopped or dropped to record its timing.
     pub fn start_at(&self, start_at: Instant) -> TimerContext {
-        self.rate.mark();
+        self.rate.mark(Instant::now());
         TimerContext {
             start_at,
             timer: self,

--- a/metriki-core/src/registry.rs
+++ b/metriki-core/src/registry.rs
@@ -239,6 +239,7 @@ impl MetricsRegistry {
 
 #[cfg(test)]
 mod test {
+    use std::time::Instant;
     use crate::filter::MetricsFilter;
     use crate::metrics::Metric;
     use crate::registry::MetricsRegistry;
@@ -247,10 +248,10 @@ mod test {
     fn test_metrics_filter() {
         let mut registry = MetricsRegistry::new();
 
-        registry.meter("l1.tomcat.request").mark();
-        registry.meter("l1.jetty.request").mark();
-        registry.meter("l2.tomcat.request").mark();
-        registry.meter("l2.jetty.request").mark();
+        registry.meter("l1.tomcat.request").mark(Instant::now());
+        registry.meter("l1.jetty.request").mark(Instant::now());
+        registry.meter("l2.tomcat.request").mark(Instant::now());
+        registry.meter("l2.jetty.request").mark(Instant::now());
 
         struct NameFilter;
         impl MetricsFilter for NameFilter {

--- a/metriki-influxdb-reporter/src/lib.rs
+++ b/metriki-influxdb-reporter/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use derive_builder::Builder;
 use influxdb::{Client, InfluxDbWriteable, Timestamp, WriteQuery};
@@ -113,9 +113,9 @@ impl InfluxDbReporter {
 
     fn report_meter(&self, name: &str, meter: &Meter) -> WriteQuery {
         self.with_query(name)
-            .add_field("m1", meter.m1_rate())
-            .add_field("m5", meter.m5_rate())
-            .add_field("m15", meter.m15_rate())
+            .add_field("m1", meter.m1_rate(Instant::now()))
+            .add_field("m5", meter.m5_rate(Instant::now()))
+            .add_field("m15", meter.m15_rate(Instant::now()))
     }
 
     fn report_gauge(&self, name: &str, gauge: &Gauge) -> WriteQuery {
@@ -152,8 +152,8 @@ impl InfluxDbReporter {
             .add_field("min", latency.min())
             .add_field("max", latency.max())
             .add_field("mean", latency.mean())
-            .add_field("m1", rate.m1_rate())
-            .add_field("m5", rate.m5_rate())
-            .add_field("m15", rate.m15_rate())
+            .add_field("m1", rate.m1_rate(Instant::now()))
+            .add_field("m5", rate.m5_rate(Instant::now()))
+            .add_field("m15", rate.m15_rate(Instant::now()))
     }
 }

--- a/metriki-log-reporter/src/lib.rs
+++ b/metriki-log-reporter/src/lib.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use derive_builder::Builder;
 use log::{log, Level};
@@ -39,14 +39,14 @@ impl LogReporter {
     }
 
     fn report_meter(&self, name: &str, meter: &Meter) {
-        log!(self.level, "{}{}.m1={}", self.prefix, name, meter.m1_rate());
-        log!(self.level, "{}{}.m5={}", self.prefix, name, meter.m5_rate());
+        log!(self.level, "{}{}.m1={}", self.prefix, name, meter.m1_rate(Instant::now()));
+        log!(self.level, "{}{}.m5={}", self.prefix, name, meter.m5_rate(Instant::now()));
         log!(
             self.level,
             "{}{}.m15={}",
             self.prefix,
             name,
-            meter.m15_rate()
+            meter.m15_rate(Instant::now())
         );
         log!(
             self.level,

--- a/metriki-r2d2/src/lib.rs
+++ b/metriki-r2d2/src/lib.rs
@@ -49,6 +49,7 @@
 //! you have multiple r2d2 pools in your application.
 //!
 use std::sync::Arc;
+use std::time::Instant;
 
 use derive_builder::Builder;
 #[cfg(not(feature = "diesel"))]
@@ -78,7 +79,7 @@ impl HandleEvent for MetrikiHandler {
     fn handle_checkout(&self, event: CheckoutEvent) {
         self.registry
             .meter(&format!("{}.checkout", self.name))
-            .mark();
+            .mark(Instant::now());
         self.registry
             .histogram(&format!("{}.wait", self.name))
             .update(event.duration().as_millis() as u64);
@@ -87,7 +88,7 @@ impl HandleEvent for MetrikiHandler {
     fn handle_timeout(&self, _event: TimeoutEvent) {
         self.registry
             .meter(&format!("{}.timeout", self.name))
-            .mark();
+            .mark(Instant::now());
     }
 
     fn handle_checkin(&self, event: CheckinEvent) {

--- a/metriki-riemann-reporter/src/lib.rs
+++ b/metriki-riemann-reporter/src/lib.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use derive_builder::Builder;
 
@@ -95,15 +95,15 @@ impl RiemannReporter {
         vec![
             self.event()
                 .service(format!("{}.m1", name))
-                .metric_d(meter.m1_rate())
+                .metric_d(meter.m1_rate(Instant::now()))
                 .build(),
             self.event()
                 .service(format!("{}.m5", name))
-                .metric_d(meter.m5_rate())
+                .metric_d(meter.m5_rate(Instant::now()))
                 .build(),
             self.event()
                 .service(format!("{}.m15", name))
-                .metric_d(meter.m15_rate())
+                .metric_d(meter.m15_rate(Instant::now()))
                 .build(),
         ]
     }
@@ -197,15 +197,15 @@ impl RiemannReporter {
                 .build(),
             self.event()
                 .service(format!("{}.m1", name))
-                .metric_d(rate.m1_rate())
+                .metric_d(rate.m1_rate(Instant::now()))
                 .build(),
             self.event()
                 .service(format!("{}.m5", name))
-                .metric_d(rate.m5_rate())
+                .metric_d(rate.m5_rate(Instant::now()))
                 .build(),
             self.event()
                 .service(format!("{}.m15", name))
-                .metric_d(rate.m15_rate())
+                .metric_d(rate.m15_rate(Instant::now()))
                 .build(),
         ]
     }

--- a/metriki-statsd-reporter/src/lib.rs
+++ b/metriki-statsd-reporter/src/lib.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::net::UdpSocket;
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use cadence::prelude::*;
 use cadence::{Metric as StatsdMetric, MetricBuilder, MetricError, StatsdClient, UdpMetricSink};
@@ -74,9 +74,9 @@ impl StatsdReporter {
     }
 
     fn report_meter(&self, name: &str, meter: &Meter, client: &StatsdClient) {
-        self.send(client.meter_with_tags(&format!("{}.m1_rate", name), meter.m1_rate() as u64));
-        self.send(client.meter_with_tags(&format!("{}.m5_rate", name), meter.m5_rate() as u64));
-        self.send(client.meter_with_tags(&format!("{}.m15_rate", name), meter.m15_rate() as u64));
+        self.send(client.meter_with_tags(&format!("{}.m1_rate", name), meter.m1_rate(Instant::now()) as u64));
+        self.send(client.meter_with_tags(&format!("{}.m5_rate", name), meter.m5_rate(Instant::now()) as u64));
+        self.send(client.meter_with_tags(&format!("{}.m15_rate", name), meter.m15_rate(Instant::now()) as u64));
         self.send(client.meter_with_tags(&format!("{}.mean_rate", name), meter.mean_rate() as u64));
     }
 
@@ -115,9 +115,9 @@ impl StatsdReporter {
         self.send(client.histogram_with_tags(&format!("{}.mean", name), latency.mean()));
         self.send(client.histogram_with_tags(&format!("{}.count", name), latency.count()));
 
-        self.send(client.meter_with_tags(&format!("{}.m1_rate", name), rate.m1_rate() as u64));
-        self.send(client.meter_with_tags(&format!("{}.m5_rate", name), rate.m5_rate() as u64));
-        self.send(client.meter_with_tags(&format!("{}.m15_rate", name), rate.m15_rate() as u64));
+        self.send(client.meter_with_tags(&format!("{}.m1_rate", name), rate.m1_rate(Instant::now()) as u64));
+        self.send(client.meter_with_tags(&format!("{}.m5_rate", name), rate.m5_rate(Instant::now()) as u64));
+        self.send(client.meter_with_tags(&format!("{}.m15_rate", name), rate.m15_rate(Instant::now()) as u64));
         self.send(client.meter_with_tags(&format!("{}.mean_rate", name), rate.mean_rate() as u64));
     }
 }

--- a/metriki-tower/src/lib.rs
+++ b/metriki-tower/src/lib.rs
@@ -7,6 +7,7 @@
 
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::Instant;
 
 use derive_builder::Builder;
 use futures::{FutureExt, TryFutureExt};
@@ -59,7 +60,7 @@ where
                 resp
             })
             .map_err(move |e| {
-                registry.meter(&format!("{}.error", name)).mark();
+                registry.meter(&format!("{}.error", name)).mark(Instant::now());
                 e
             });
 

--- a/metriki-tracing/src/lib.rs
+++ b/metriki-tracing/src/lib.rs
@@ -13,6 +13,7 @@
 //! apis.
 //!
 use std::sync::Arc;
+use std::time::Instant;
 
 use tracing::Subscriber;
 use tracing::{Event, Id};
@@ -50,7 +51,7 @@ where
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
         // register event as meter
         // FIXME: better event metrics name
-        self.registry.meter(event.metadata().name()).mark();
+        self.registry.meter(event.metadata().name()).mark(Instant::now());
     }
 
     fn on_enter(&self, _id: &Id, ctx: Context<'_, S>) {


### PR DESCRIPTION
In simulation it is not always Instant::now and sometimes needs to be supplied from the outside

(I am not proposing it upstream because it only is needed in simulation)